### PR TITLE
Add check() method and variable name tracking for vitest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+- `Property.check()` method for formatted test output in vitest and other test frameworks
+- Clear counterexample display with shrink count, original failure, and reproduction info
+- Formatted classification statistics in failure output
+- `forAllNamed()` function for variable name tracking in failure reports
+- Variable names shown in counterexample output (e.g., `forAll 0 = 42 -- x`)
+
+### Removed
+- Noisy duplicate key warning from state machine testing
+
 ## [0.3.0] - 2025-10-04
 
 ### Fixed

--- a/packages/hedgehog/src/concurrent.ts
+++ b/packages/hedgehog/src/concurrent.ts
@@ -84,7 +84,10 @@ export class ConcurrentProperty<T> {
     let raceConditionTests = 0;
 
     for (let i = 0; i < testConfig.testLimit; i++) {
-      const input = this.generator.generate(Size.of(i), Seed.fromNumber(i * 1000)).value;
+      const input = this.generator.generate(
+        Size.of(i),
+        Seed.fromNumber(i * 1000)
+      ).value;
 
       // Run the same test multiple times concurrently
       const promises = Array.from({ length: this.config.workerCount }, () =>
@@ -96,8 +99,8 @@ export class ConcurrentProperty<T> {
 
         // Check if all results are the same (deterministic)
         const firstResult = results[0];
-        const consistent = results.every(result =>
-          JSON.stringify(result) === JSON.stringify(firstResult)
+        const consistent = results.every(
+          (result) => JSON.stringify(result) === JSON.stringify(firstResult)
         );
 
         testResults.push({
@@ -123,7 +126,8 @@ export class ConcurrentProperty<T> {
     }
 
     const totalTests = testConfig.testLimit;
-    const determinismRate = totalTests > 0 ? deterministicTests / totalTests : 1;
+    const determinismRate =
+      totalTests > 0 ? deterministicTests / totalTests : 1;
 
     return {
       summary: {
@@ -179,11 +183,15 @@ export async function detectRaceConditions<T>(
   return {
     determinismRate: result.summary.determinismRate,
     hasRaceConditions: result.summary.raceConditionTests > 0,
-    patterns: result.summary.raceConditionTests > 0 ? [
-      {
-        description: 'Non-deterministic behavior detected',
-        frequency: result.summary.raceConditionTests / result.summary.totalTests,
-      }
-    ] : [],
+    patterns:
+      result.summary.raceConditionTests > 0
+        ? [
+            {
+              description: 'Non-deterministic behavior detected',
+              frequency:
+                result.summary.raceConditionTests / result.summary.totalTests,
+            },
+          ]
+        : [],
   };
 }

--- a/packages/hedgehog/src/config.ts
+++ b/packages/hedgehog/src/config.ts
@@ -4,7 +4,12 @@
 export class Config {
   constructor(
     configOrTestLimit?:
-      | { testLimit?: number; shrinkLimit?: number; sizeLimit?: number; discardLimit?: number }
+      | {
+          testLimit?: number;
+          shrinkLimit?: number;
+          sizeLimit?: number;
+          discardLimit?: number;
+        }
       | number,
     shrinkLimit: number = 1000,
     sizeLimit: number = 100,

--- a/packages/hedgehog/src/gen.ts
+++ b/packages/hedgehog/src/gen.ts
@@ -161,7 +161,10 @@ export class Gen<T> {
     return new Gen(generators.constant(value));
   }
 
-  static oneOf<T>(genListOrFirst?: Gen<T>[] | Gen<T>, ...rest: Gen<T>[]): Gen<T> {
+  static oneOf<T>(
+    genListOrFirst?: Gen<T>[] | Gen<T>,
+    ...rest: Gen<T>[]
+  ): Gen<T> {
     let genList: Gen<T>[];
 
     if (genListOrFirst === undefined) {
@@ -205,8 +208,8 @@ export class Gen<T> {
     if (args.length > 0) {
       throw new Error(
         'Gen.string() does not accept parameters. ' +
-        'For variable-length strings, use: Gen.int(Range.uniform(min, max)).bind(len => Gen.stringOfLength(len)) ' +
-        'or the convenience method Gen.stringBetween(min, max)'
+          'For variable-length strings, use: Gen.int(Range.uniform(min, max)).bind(len => Gen.stringOfLength(len)) ' +
+          'or the convenience method Gen.stringBetween(min, max)'
       );
     }
     const generatorFn = string();
@@ -219,7 +222,7 @@ export class Gen<T> {
   }
 
   static stringOfRange(range: Range<number>): Gen<string> {
-    return Gen.int(range).bind(length => Gen.stringOfLength(length));
+    return Gen.int(range).bind((length) => Gen.stringOfLength(length));
   }
 
   static stringBetween(min: number, max: number): Gen<string> {
@@ -254,8 +257,8 @@ export class Gen<T> {
   static fromSchema<T>(_schema: any): Gen<T> {
     throw new Error(
       'Zod integration has been moved to a separate import.\n' +
-      'Use: import { fromSchema } from \'@justanotherdot/hedgehog/zod\'\n' +
-      'Make sure to install zod: npm install zod'
+        "Use: import { fromSchema } from '@justanotherdot/hedgehog/zod'\n" +
+        'Make sure to install zod: npm install zod'
     );
   }
 

--- a/packages/hedgehog/src/index.ts
+++ b/packages/hedgehog/src/index.ts
@@ -14,7 +14,7 @@ export {
   DateOptions,
   ArrayOptions,
 } from './gen.js';
-export { Property, forAll } from './property.js';
+export { Property, forAll, forAllNamed } from './property.js';
 export { Config } from './config.js';
 export {
   TestResult,

--- a/packages/hedgehog/src/meta/debug-workers.test.ts
+++ b/packages/hedgehog/src/meta/debug-workers.test.ts
@@ -92,21 +92,21 @@ if (parentPort) {
     // Check for common container indicators
     const indicators = {
       'Container env vars': {
-        'CI': process.env.CI,
-        'GITHUB_ACTIONS': process.env.GITHUB_ACTIONS,
-        'RUNNER_OS': process.env.RUNNER_OS,
-        'CONTAINER': process.env.CONTAINER,
+        CI: process.env.CI,
+        GITHUB_ACTIONS: process.env.GITHUB_ACTIONS,
+        RUNNER_OS: process.env.RUNNER_OS,
+        CONTAINER: process.env.CONTAINER,
       },
       'Process info': {
-        'PID': process.pid,
-        'PPID': process.ppid,
-        'UID': process.getuid?.(),
-        'GID': process.getgid?.(),
+        PID: process.pid,
+        PPID: process.ppid,
+        UID: process.getuid?.(),
+        GID: process.getgid?.(),
       },
       'Resource limits': {
         'Memory usage': process.memoryUsage(),
         'CPU usage': process.cpuUsage(),
-      }
+      },
     };
 
     console.log('Environment indicators:', JSON.stringify(indicators, null, 2));
@@ -117,7 +117,10 @@ if (parentPort) {
       const cgroup = fs.readFileSync('/proc/1/cgroup', 'utf8');
       console.log('Container cgroup info:', cgroup);
     } catch (error) {
-      console.log('Could not read cgroup info (not Linux or no access):', error.message);
+      console.log(
+        'Could not read cgroup info (not Linux or no access):',
+        error.message
+      );
     }
 
     expect(true).toBe(true); // Always pass, this is just for logging
@@ -173,7 +176,9 @@ if (parentPort) {
           }
         });
 
-        console.log('ES module worker event listeners set up, waiting for message...');
+        console.log(
+          'ES module worker event listeners set up, waiting for message...'
+        );
       });
 
       await worker.terminate();
@@ -181,7 +186,10 @@ if (parentPort) {
 
       expect(result).toEqual({ type: 'ready', module: 'es' });
     } catch (error) {
-      console.log('ES module worker failed (this might be expected):', error.message);
+      console.log(
+        'ES module worker failed (this might be expected):',
+        error.message
+      );
       // Don't fail the test - ES modules might not be supported
       expect(true).toBe(true);
     } finally {

--- a/packages/hedgehog/src/meta/parallel-properties.test.ts
+++ b/packages/hedgehog/src/meta/parallel-properties.test.ts
@@ -45,7 +45,9 @@ describe('Parallel Property Testing Meta-Tests', () => {
       expect(result.workerResults).toHaveLength(workerCount);
 
       // Each worker should have executed approximately the same number of tests
-      const testCounts = result.workerResults.map(wr => wr.timing.testsExecuted);
+      const testCounts = result.workerResults.map(
+        (wr) => wr.timing.testsExecuted
+      );
       const expectedPerWorker = Math.floor(9 / workerCount);
 
       for (const count of testCounts) {
@@ -71,7 +73,8 @@ describe('Parallel Property Testing Meta-Tests', () => {
 
       // Total tests executed should equal test count
       const totalExecuted = result.workerResults.reduce(
-        (sum, wr) => sum + wr.timing.testsExecuted, 0
+        (sum, wr) => sum + wr.timing.testsExecuted,
+        0
       );
       expect(totalExecuted).toBe(testCount);
     });
@@ -101,11 +104,7 @@ describe('Parallel Property Testing Meta-Tests', () => {
     });
 
     it('should track worker efficiency', async () => {
-      const property = forAllParallel(
-        Gen.int(1, 100),
-        (n) => n > 0,
-        2
-      );
+      const property = forAllParallel(Gen.int(1, 100), (n) => n > 0, 2);
 
       const config = new Config({ testLimit: 20 });
       const result = await property.run(config);
@@ -216,7 +215,9 @@ describe('Parallel Property Testing Meta-Tests', () => {
       expect(result1.outcome.type).toBe(result2.outcome.type);
 
       if (result1.outcome.type === 'fail' && result2.outcome.type === 'fail') {
-        expect(result1.outcome.counterexample).toBe(result2.outcome.counterexample);
+        expect(result1.outcome.counterexample).toBe(
+          result2.outcome.counterexample
+        );
       }
     });
   });
@@ -238,7 +239,9 @@ describe('Parallel Property Testing Meta-Tests', () => {
       // Check if load balancing issues are detected
       // Note: This might not always trigger depending on work distribution
       if (result.issues.loadBalancingIssues.length > 0) {
-        expect(result.issues.loadBalancingIssues[0]).toContain('Load imbalance');
+        expect(result.issues.loadBalancingIssues[0]).toContain(
+          'Load imbalance'
+        );
       }
     });
   });
@@ -253,14 +256,10 @@ describe('Parallel Property Testing Meta-Tests', () => {
 
           // Sequential execution
           const sequentialResults = inputs.map(testFn);
-          const sequentialPassed = sequentialResults.every(r => r);
+          const sequentialPassed = sequentialResults.every((r) => r);
 
           // Parallel execution
-          const parallelProperty = forAllParallel(
-            Gen.oneOf(inputs),
-            testFn,
-            2
-          );
+          const parallelProperty = forAllParallel(Gen.oneOf(inputs), testFn, 2);
 
           const config = new Config({ testLimit: inputs.length });
           const parallelResult = await parallelProperty.run(config);

--- a/packages/hedgehog/src/meta/state-machine-internals.test.ts
+++ b/packages/hedgehog/src/meta/state-machine-internals.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Environment, type Variable } from '../state.js';
-import { command, require, update, ensure, executeSequential, newVar } from '../state.js';
+import {
+  command,
+  require,
+  update,
+  ensure,
+  executeSequential,
+  newVar,
+} from '../state.js';
 import { Gen } from '../gen.js';
 import { Range } from '../data/size.js';
 
@@ -93,9 +100,21 @@ describe('State Machine Internals', () => {
         type: 'sequential' as const,
         initialState: { items: [] },
         actions: [
-          { command: addItem, input: { value: 'item-1' }, output: newVar<string>() },
-          { command: addItem, input: { value: 'item-1' }, output: newVar<string>() },
-          { command: addItem, input: { value: 'item-1' }, output: newVar<string>() },
+          {
+            command: addItem,
+            input: { value: 'item-1' },
+            output: newVar<string>(),
+          },
+          {
+            command: addItem,
+            input: { value: 'item-1' },
+            output: newVar<string>(),
+          },
+          {
+            command: addItem,
+            input: { value: 'item-1' },
+            output: newVar<string>(),
+          },
         ],
       };
 
@@ -120,13 +139,18 @@ describe('State Machine Internals', () => {
         },
         require(() => true),
         update((state, input, outputVar) => {
-          const userId = outputVar.type === 'symbolic' ? outputVar.toString() : outputVar.value;
+          const userId =
+            outputVar.type === 'symbolic'
+              ? outputVar.toString()
+              : outputVar.value;
           return {
             users: { ...state.users, [userId]: outputVar },
           };
         }),
         ensure((_before, after, _input, _output) => {
-          return Object.keys(after.users).length === Object.keys(realUsers).length;
+          return (
+            Object.keys(after.users).length === Object.keys(realUsers).length
+          );
         })
       );
 
@@ -134,8 +158,16 @@ describe('State Machine Internals', () => {
         type: 'sequential' as const,
         initialState: { users: {} },
         actions: [
-          { command: createUser, input: { name: 'Alice' }, output: newVar<string>() },
-          { command: createUser, input: { name: 'Bob' }, output: newVar<string>() },
+          {
+            command: createUser,
+            input: { name: 'Alice' },
+            output: newVar<string>(),
+          },
+          {
+            command: createUser,
+            input: { name: 'Bob' },
+            output: newVar<string>(),
+          },
         ],
       };
 
@@ -172,9 +204,21 @@ describe('State Machine Internals', () => {
         type: 'sequential' as const,
         initialState: { items: [] },
         actions: [
-          { command: addItem, input: { id: 'duplicate-id' }, output: newVar<string>() },
-          { command: addItem, input: { id: 'duplicate-id' }, output: newVar<string>() },
-          { command: addItem, input: { id: 'duplicate-id' }, output: newVar<string>() },
+          {
+            command: addItem,
+            input: { id: 'duplicate-id' },
+            output: newVar<string>(),
+          },
+          {
+            command: addItem,
+            input: { id: 'duplicate-id' },
+            output: newVar<string>(),
+          },
+          {
+            command: addItem,
+            input: { id: 'duplicate-id' },
+            output: newVar<string>(),
+          },
         ],
       };
 
@@ -190,7 +234,11 @@ describe('State Machine Internals', () => {
 
       const realTeams = new Map<string, { members: string[] }>();
 
-      const addMember = command<State, { teamId: string; name: string }, string>(
+      const addMember = command<
+        State,
+        { teamId: string; name: string },
+        string
+      >(
         (_state) =>
           Gen.object({
             teamId: Gen.constant('team-1'),

--- a/packages/hedgehog/src/meta/worker-management.test.ts
+++ b/packages/hedgehog/src/meta/worker-management.test.ts
@@ -6,7 +6,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { WorkerLikePool, defaultWorkerLikePoolConfig, getWorkerLikePool, shutdownWorkerLikePool } from '../worker.js';
+import {
+  WorkerLikePool,
+  defaultWorkerLikePoolConfig,
+  getWorkerLikePool,
+  shutdownWorkerLikePool,
+} from '../worker.js';
 
 describe('Worker Management Meta-Tests', () => {
   let workerPool: WorkerLikePool;
@@ -91,14 +96,16 @@ describe('Worker Management Meta-Tests', () => {
 
       try {
         const slowTestFunction = async (_input: number) => {
-          await new Promise(resolve => setTimeout(resolve, 500)); // Longer than 100ms timeout
+          await new Promise((resolve) => setTimeout(resolve, 500)); // Longer than 100ms timeout
           return {
             type: 'pass' as const,
             testsRun: 1,
           };
         };
 
-        await expect(timeoutPool.executeTest(42, slowTestFunction)).rejects.toThrow();
+        await expect(
+          timeoutPool.executeTest(42, slowTestFunction)
+        ).rejects.toThrow();
       } finally {
         await timeoutPool.shutdown();
       }
@@ -133,12 +140,15 @@ describe('Worker Management Meta-Tests', () => {
       const initialStats = workerPool.getStatus();
       expect(initialStats.activeTests).toBe(0);
 
-      const result = await workerPool.executeTest(42, async (_input: number) => {
-        return {
-          type: 'pass' as const,
-          testsRun: 1,
-        };
-      });
+      const result = await workerPool.executeTest(
+        42,
+        async (_input: number) => {
+          return {
+            type: 'pass' as const,
+            testsRun: 1,
+          };
+        }
+      );
 
       expect(result.success).toBe(true);
 
@@ -171,7 +181,7 @@ describe('Worker Management Meta-Tests', () => {
       }
 
       // Should have used both workers
-      const workerIds = new Set(results.map(r => r.workerId));
+      const workerIds = new Set(results.map((r) => r.workerId));
       expect(workerIds.size).toBeGreaterThan(1);
     });
 
@@ -231,7 +241,6 @@ describe('Worker Management Meta-Tests', () => {
       expect(finalStats.totalWorkers).toBe(0);
       expect(finalStats.pendingTests).toBe(0);
     });
-
   });
 
   describe('Health Checking', () => {
@@ -248,7 +257,6 @@ describe('Worker Management Meta-Tests', () => {
       expect(result.success).toBe(true);
     });
   });
-
 
   describe('Global Worker Pool Management', () => {
     afterEach(async () => {
@@ -300,7 +308,7 @@ describe('Worker Management Meta-Tests', () => {
         // This closure won't work in workers due to variable serialization limits
         const result = input * multiplier;
         return {
-          type: result > 0 ? 'pass' as const : 'fail' as const,
+          type: result > 0 ? ('pass' as const) : ('fail' as const),
           testsRun: 1,
         };
       };
@@ -310,7 +318,10 @@ describe('Worker Management Meta-Tests', () => {
         const result = await workerPool.executeTest(5, testFunction);
 
         // If we get here, check if it's a failure result
-        if (!result.success && result.error?.includes('multiplier is not defined')) {
+        if (
+          !result.success &&
+          result.error?.includes('multiplier is not defined')
+        ) {
           // Alternative expected failure if closure made it through but failed at runtime
           expect(result.error).toContain('multiplier is not defined');
         } else {
@@ -320,7 +331,9 @@ describe('Worker Management Meta-Tests', () => {
       } catch (error) {
         // Expected: Function validation should reject closures
         expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toContain('not safe for worker execution');
+        expect((error as Error).message).toContain(
+          'not safe for worker execution'
+        );
         expect((error as Error).message).toContain('multiplier');
       }
     });

--- a/packages/hedgehog/src/parallel.ts
+++ b/packages/hedgehog/src/parallel.ts
@@ -148,7 +148,7 @@ export class ParallelProperty<T> {
     /** Parallel execution configuration */
     public readonly config: ParallelConfig,
     /** Variable name for debugging */
-    public readonly variableName?: string,
+    public readonly variableName?: string
   ) {}
 
   /**
@@ -159,7 +159,7 @@ export class ParallelProperty<T> {
       this.generator,
       this.testFunction,
       this.config,
-      name,
+      name
     );
   }
 
@@ -181,12 +181,18 @@ export class ParallelProperty<T> {
       const workDistribution = this.distributeWork(testInputs);
 
       // Execute tests in parallel
-      const workerResults = await this.executeWorkersInParallel(workerPool, workDistribution);
+      const workerResults = await this.executeWorkersInParallel(
+        workerPool,
+        workDistribution
+      );
 
       // Analyze results and compute metrics
       const totalDuration = performance.now() - startTime;
       const outcome = this.aggregateResults(workerResults);
-      const performanceMetrics = this.calculatePerformanceMetrics(totalDuration, workerResults);
+      const performanceMetrics = this.calculatePerformanceMetrics(
+        totalDuration,
+        workerResults
+      );
       const issues = this.analyzeExecutionIssues(workerResults);
 
       return {
@@ -225,7 +231,10 @@ export class ParallelProperty<T> {
 
     switch (this.config.workDistribution) {
       case 'round-robin': {
-        const workerInputs: T[][] = Array.from({ length: workerCount }, () => []);
+        const workerInputs: T[][] = Array.from(
+          { length: workerCount },
+          () => []
+        );
 
         for (let i = 0; i < totalTests; i++) {
           const workerIndex = i % workerCount;
@@ -255,7 +264,9 @@ export class ParallelProperty<T> {
       }
 
       default:
-        throw new Error(`Unknown work distribution strategy: ${this.config.workDistribution}`);
+        throw new Error(
+          `Unknown work distribution strategy: ${this.config.workDistribution}`
+        );
     }
   }
 
@@ -310,14 +321,17 @@ export class ParallelProperty<T> {
             return {
               workerId,
               result: failureResult,
-              timing: this.calculateWorkerTiming(startTime, testsRun + 1, totalTestTime),
+              timing: this.calculateWorkerTiming(
+                startTime,
+                testsRun + 1,
+                totalTestTime
+              ),
               errors: [...errors, 'Property test failed'],
             };
           }
 
           testsRun++;
           totalTestTime += performance.now() - testStartTime;
-
         } catch (error) {
           errors.push(`Test execution error: ${error}`);
 
@@ -334,7 +348,11 @@ export class ParallelProperty<T> {
           return {
             workerId,
             result: errorResult,
-            timing: this.calculateWorkerTiming(startTime, testsRun + 1, totalTestTime),
+            timing: this.calculateWorkerTiming(
+              startTime,
+              testsRun + 1,
+              totalTestTime
+            ),
             errors,
           };
         }
@@ -353,7 +371,6 @@ export class ParallelProperty<T> {
         timing: this.calculateWorkerTiming(startTime, testsRun, totalTestTime),
         errors,
       };
-
     } catch (error) {
       errors.push(`Worker execution error: ${error}`);
 
@@ -376,7 +393,6 @@ export class ParallelProperty<T> {
     }
   }
 
-
   /**
    * Calculate timing information for a worker.
    */
@@ -386,7 +402,8 @@ export class ParallelProperty<T> {
     totalTestTime: number
   ): WorkerTimingInfo {
     const totalTime = performance.now() - startTime;
-    const averageTimePerTest = testsExecuted > 0 ? totalTestTime / testsExecuted : 0;
+    const averageTimePerTest =
+      testsExecuted > 0 ? totalTestTime / testsExecuted : 0;
     const idleTime = Math.max(0, totalTime - totalTestTime);
 
     return {
@@ -400,7 +417,9 @@ export class ParallelProperty<T> {
   /**
    * Aggregate results from all workers into a single result.
    */
-  private aggregateResults(workerResults: WorkerExecutionResult[]): ParallelTestResultType {
+  private aggregateResults(
+    workerResults: WorkerExecutionResult[]
+  ): ParallelTestResultType {
     // If any worker failed, the overall test failed
     for (const workerResult of workerResults) {
       if (workerResult.result.type === 'fail') {
@@ -410,7 +429,10 @@ export class ParallelProperty<T> {
 
     // All workers passed - aggregate the success
     const totalTests = workerResults.reduce((sum, workerResult) => {
-      return sum + (workerResult.result.type === 'pass' ? workerResult.result.testsRun : 0);
+      return (
+        sum +
+        (workerResult.result.type === 'pass' ? workerResult.result.testsRun : 0)
+      );
     }, 0);
 
     return {
@@ -436,14 +458,17 @@ export class ParallelProperty<T> {
     }, 0);
 
     // Estimate what sequential execution would have taken
-    const averageTestTime = workerResults.reduce((sum, result) => {
-      return sum + result.timing.averageTimePerTest;
-    }, 0) / workerResults.length;
+    const averageTestTime =
+      workerResults.reduce((sum, result) => {
+        return sum + result.timing.averageTimePerTest;
+      }, 0) / workerResults.length;
 
     const estimatedSequentialTime = totalTests * averageTestTime;
-    const speedupFactor = estimatedSequentialTime > 0 ? estimatedSequentialTime / totalDuration : 1;
+    const speedupFactor =
+      estimatedSequentialTime > 0 ? estimatedSequentialTime / totalDuration : 1;
     const workerEfficiency = speedupFactor / this.config.workerCount;
-    const testsPerSecond = totalDuration > 0 ? (totalTests * 1000) / totalDuration : 0;
+    const testsPerSecond =
+      totalDuration > 0 ? (totalTests * 1000) / totalDuration : 0;
 
     return {
       totalDuration,
@@ -457,7 +482,9 @@ export class ParallelProperty<T> {
   /**
    * Analyze worker results for execution issues.
    */
-  private analyzeExecutionIssues(workerResults: WorkerExecutionResult[]): ParallelExecutionIssues {
+  private analyzeExecutionIssues(
+    workerResults: WorkerExecutionResult[]
+  ): ParallelExecutionIssues {
     const workerFailures: string[] = [];
     const timeouts: string[] = [];
     const loadBalancingIssues: string[] = [];
@@ -471,7 +498,7 @@ export class ParallelProperty<T> {
     }
 
     // Analyze load balancing
-    const testCounts = workerResults.map(r => r.timing.testsExecuted);
+    const testCounts = workerResults.map((r) => r.timing.testsExecuted);
     const maxTests = Math.max(...testCounts);
     const minTests = Math.min(...testCounts);
     const imbalanceRatio = maxTests > 0 ? minTests / maxTests : 1;
@@ -483,9 +510,18 @@ export class ParallelProperty<T> {
     }
 
     // Analyze timing efficiency
-    const totalIdleTime = workerResults.reduce((sum, r) => sum + r.timing.idleTime, 0);
-    const totalActiveTime = workerResults.reduce((sum, r) => sum + r.timing.totalTime - r.timing.idleTime, 0);
-    const idlePercentage = totalActiveTime > 0 ? (totalIdleTime / (totalIdleTime + totalActiveTime)) * 100 : 0;
+    const totalIdleTime = workerResults.reduce(
+      (sum, r) => sum + r.timing.idleTime,
+      0
+    );
+    const totalActiveTime = workerResults.reduce(
+      (sum, r) => sum + r.timing.totalTime - r.timing.idleTime,
+      0
+    );
+    const idlePercentage =
+      totalActiveTime > 0
+        ? (totalIdleTime / (totalIdleTime + totalActiveTime)) * 100
+        : 0;
 
     if (idlePercentage > 20) {
       resourceWarnings.push(
@@ -504,7 +540,10 @@ export class ParallelProperty<T> {
   /**
    * Create error result for parallel execution failure.
    */
-  private createErrorResult(error: unknown, duration: number): ParallelTestResult {
+  private createErrorResult(
+    error: unknown,
+    duration: number
+  ): ParallelTestResult {
     const failureResult: ParallelTestResultType = {
       type: 'fail',
       counterexample: `Parallel execution error: ${error}`,
@@ -553,7 +592,7 @@ export class ParallelProperty<T> {
 export function forAllParallel<T>(
   generator: Gen<T>,
   condition: (input: T) => boolean | Promise<boolean>,
-  workerCount: number = defaultParallelConfig().workerCount,
+  workerCount: number = defaultParallelConfig().workerCount
 ): ParallelProperty<T> {
   const config: ParallelConfig = {
     ...defaultParallelConfig(),
@@ -572,7 +611,7 @@ export function forAllParallel<T>(
 export function parallelProperty<T>(
   generator: Gen<T>,
   condition: (input: T) => boolean | Promise<boolean>,
-  config: ParallelConfig = defaultParallelConfig(),
+  config: ParallelConfig = defaultParallelConfig()
 ): ParallelProperty<T> {
   return new ParallelProperty(generator, condition, config);
 }
@@ -585,8 +624,10 @@ export function parallelProperty<T>(
  */
 export function parallelPropertyWithResult<T>(
   generator: Gen<T>,
-  testFunction: (input: T) => ParallelTestResultType | Promise<ParallelTestResultType>,
-  config: ParallelConfig = defaultParallelConfig(),
+  testFunction: (
+    input: T
+  ) => ParallelTestResultType | Promise<ParallelTestResultType>,
+  config: ParallelConfig = defaultParallelConfig()
 ): ParallelProperty<T> {
   // Convert TestResult-returning function to boolean-returning function
   const booleanFunction = async (input: T): Promise<boolean> => {

--- a/packages/hedgehog/src/property-check.test.ts
+++ b/packages/hedgehog/src/property-check.test.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect } from 'vitest';
+import { forAll, forAllNamed } from './property.js';
+import { Gen, Ints } from './gen.js';
+import { Config } from './config.js';
+import { Seed } from './data/seed.js';
+
+describe('Property check method', () => {
+  test('check passes when property holds', () => {
+    const prop = forAll(Ints.small(), (x) => x >= 0 && x <= 100);
+
+    expect(() => {
+      prop.check(Config.default().withTests(50), Seed.fromNumber(42));
+    }).not.toThrow();
+  });
+
+  test('check throws with formatted output when property fails', () => {
+    const prop = forAll(Ints.range(0, 100), (x) => x < 50);
+
+    expect(() => {
+      prop.check(Config.default().withTests(100), Seed.fromNumber(42));
+    }).toThrowError(/Property failed/);
+  });
+
+  test('formatted failure includes counterexample', () => {
+    const prop = forAll(Ints.range(0, 100), (x) => x < 50);
+
+    try {
+      prop.check(Config.default().withTests(100), Seed.fromNumber(42));
+      throw new Error('Expected property to fail');
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).toContain('Counterexample');
+      expect(message).toContain('shrinks');
+      expect(message).toContain('Reproduce with');
+      expect(message).toContain('seed:');
+    }
+  });
+
+  test('formatted failure shows original failure when shrunk', () => {
+    const prop = forAll(Ints.range(0, 100), (x) => x < 10);
+
+    try {
+      prop.check(Config.default().withTests(100), Seed.fromNumber(123));
+      throw new Error('Expected property to fail');
+    } catch (error) {
+      const message = (error as Error).message;
+
+      if (message.includes('Original failure')) {
+        expect(message).toContain('Counterexample');
+        expect(message).toContain('Original failure');
+      }
+    }
+  });
+
+  test('formatted failure includes classification statistics', () => {
+    const prop = forAll(Ints.range(0, 100), (x) => x < 50)
+      .classify('small', (x) => x < 25)
+      .classify('medium', (x) => x >= 25 && x < 75);
+
+    try {
+      prop.check(Config.default().withTests(100), Seed.fromNumber(42));
+      throw new Error('Expected property to fail');
+    } catch (error) {
+      const message = (error as Error).message;
+
+      if (message.includes('Classification')) {
+        expect(message).toContain('Classification');
+      }
+    }
+  });
+
+  test('check throws with formatted output on gave up', () => {
+    const neverPasses = Gen.int().filter(() => false);
+    const prop = forAll(neverPasses, () => true);
+
+    expect(() => {
+      prop.check(
+        Config.default().withTests(10).withDiscardLimit(5),
+        Seed.fromNumber(42)
+      );
+    }).toThrowError(/Property gave up/);
+  });
+
+  test('array formatting truncates long arrays', () => {
+    const longArray = Gen.array(Ints.small()).map((xs) => {
+      while (xs.length < 20) xs.push(1);
+      return xs;
+    });
+    const prop = forAll(longArray, (xs) => xs.length < 15);
+
+    try {
+      prop.check(Config.default().withTests(100), Seed.fromNumber(42));
+      throw new Error('Expected property to fail');
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).toContain('items total');
+    }
+  });
+});
+
+describe('Variable name tracking', () => {
+  test('forAllNamed shows variable name in failure', () => {
+    const prop = forAllNamed('x', Ints.range(0, 100), (x) => x < 50);
+
+    try {
+      prop.check(Config.default().withTests(100), Seed.fromNumber(42));
+      throw new Error('Expected property to fail');
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).toContain('forAll 0 =');
+      expect(message).toContain('-- x');
+    }
+  });
+
+  test('forAll without name does not show variable annotation', () => {
+    const prop = forAll(Ints.range(0, 100), (x) => x < 50);
+
+    try {
+      prop.check(Config.default().withTests(100), Seed.fromNumber(42));
+      throw new Error('Expected property to fail');
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).not.toContain('forAll 0 =');
+      expect(message).not.toContain('--');
+    }
+  });
+
+  test('variable name preserved through classify', () => {
+    const prop = forAllNamed(
+      'number',
+      Ints.range(0, 100),
+      (x) => x < 50
+    ).classify('small', (x) => x < 25);
+
+    try {
+      prop.check(Config.default().withTests(100), Seed.fromNumber(42));
+      throw new Error('Expected property to fail');
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).toContain('forAll 0 =');
+      expect(message).toContain('-- number');
+    }
+  });
+
+  test('variable name shown in original failure when shrinking', () => {
+    const prop = forAllNamed('value', Ints.range(0, 100), (x) => x < 10);
+
+    try {
+      prop.check(Config.default().withTests(100), Seed.fromNumber(123));
+      throw new Error('Expected property to fail');
+    } catch (error) {
+      const message = (error as Error).message;
+
+      if (message.includes('Original failure')) {
+        expect(message).toContain('forAll 0 =');
+        expect(message).toContain('-- value');
+        // Should appear twice: once for counterexample, once for original
+        const matches = message.match(/-- value/g);
+        expect(matches).toHaveLength(2);
+      }
+    }
+  });
+});

--- a/packages/hedgehog/src/seed/adaptive.ts
+++ b/packages/hedgehog/src/seed/adaptive.ts
@@ -157,14 +157,19 @@ export class AdaptiveSeed implements BulkSeed {
   }
 
   nextBounded(bound: number): [number, AdaptiveSeed] {
-    if (bound === undefined || bound === null || !Number.isFinite(bound) || bound < 0) {
+    if (
+      bound === undefined ||
+      bound === null ||
+      !Number.isFinite(bound) ||
+      bound < 0
+    ) {
       throw new Error(
         `Invalid bound parameter: ${bound}. ` +
-        'This often indicates an API usage error. ' +
-        'Common causes:\n' +
-        '  - Using Gen.string(Range.uniform(min, max)) - use Gen.stringBetween(min, max) instead\n' +
-        '  - Passing undefined/null values to generators\n' +
-        '  - Using negative bounds'
+          'This often indicates an API usage error. ' +
+          'Common causes:\n' +
+          '  - Using Gen.string(Range.uniform(min, max)) - use Gen.stringBetween(min, max) instead\n' +
+          '  - Passing undefined/null values to generators\n' +
+          '  - Using negative bounds'
       );
     }
 

--- a/packages/hedgehog/src/seed/wasm.ts
+++ b/packages/hedgehog/src/seed/wasm.ts
@@ -47,15 +47,20 @@ export class Seed implements BulkSeed {
   }
 
   nextBounded(bound: number): [number, Seed] {
-    if (bound === undefined || bound === null || !Number.isFinite(bound) || bound < 0) {
+    if (
+      bound === undefined ||
+      bound === null ||
+      !Number.isFinite(bound) ||
+      bound < 0
+    ) {
       throw new Error(
         `Invalid bound parameter: ${bound}. ` +
-        'This often indicates an API usage error. ' +
-        'Common causes:\n' +
-        '  - Using Gen.string(Range.uniform(min, max)) - Gen.string() takes no parameters\n' +
-        '  - Passing undefined/null values to generators\n' +
-        '  - Using negative bounds\n' +
-        'For variable-length strings, use: Gen.int(Range.uniform(min, max)).bind(len => Gen.stringOfLength(len))'
+          'This often indicates an API usage error. ' +
+          'Common causes:\n' +
+          '  - Using Gen.string(Range.uniform(min, max)) - Gen.string() takes no parameters\n' +
+          '  - Passing undefined/null values to generators\n' +
+          '  - Using negative bounds\n' +
+          'For variable-length strings, use: Gen.int(Range.uniform(min, max)).bind(len => Gen.stringOfLength(len))'
       );
     }
     const result = this.wasmSeed.next_bounded(BigInt(bound));

--- a/packages/hedgehog/src/state-variable-map-key.test.ts
+++ b/packages/hedgehog/src/state-variable-map-key.test.ts
@@ -38,11 +38,15 @@ describe('Map<Variable, Data> - Variables as Keys', () => {
       update((state, input, idVar) => {
         const newItems = new Map(state.items);
         newItems.set(idVar, input.value);
-        console.log(`[Update] Added with key ${idVar.toString()}, map size: ${newItems.size}`);
+        console.log(
+          `[Update] Added with key ${idVar.toString()}, map size: ${newItems.size}`
+        );
         return { items: newItems };
       }),
       ensure((_before, after, _input, _output) => {
-        console.log(`[Ensure] Model size: ${after.items.size}, Real size: ${realMap.size}`);
+        console.log(
+          `[Ensure] Model size: ${after.items.size}, Real size: ${realMap.size}`
+        );
         return after.items.size === realMap.size;
       })
     );
@@ -54,14 +58,14 @@ describe('Map<Variable, Data> - Variables as Keys', () => {
         {
           command: addItem,
           input: { value: 100 },
-          output: { type: 'symbolic' as const, id: 0, typeName: 'string' }
+          output: { type: 'symbolic' as const, id: 0, typeName: 'string' },
         },
         {
           command: addItem,
           input: { value: 200 },
-          output: { type: 'symbolic' as const, id: 1, typeName: 'string' }
-        }
-      ]
+          output: { type: 'symbolic' as const, id: 1, typeName: 'string' },
+        },
+      ],
     };
 
     console.log('\n=== Map<Variable<string>, number> Test ===\n');
@@ -70,8 +74,12 @@ describe('Map<Variable, Data> - Variables as Keys', () => {
     console.log(`\nFinal Result: ${result.success ? 'PASS' : 'FAIL'}`);
     console.log(`Model map size: ${sequence.initialState.items.size}`);
     console.log(`Real map size: ${realMap.size}`);
-    console.log('\nExpected: Both should have 1 entry (duplicate ID overwrites)');
-    console.log(`Actual: Model=${sequence.initialState.items.size}, Real=${realMap.size}`);
+    console.log(
+      '\nExpected: Both should have 1 entry (duplicate ID overwrites)'
+    );
+    console.log(
+      `Actual: Model=${sequence.initialState.items.size}, Real=${realMap.size}`
+    );
 
     // What's the actual behavior?
     expect(result.success).toBeDefined();
@@ -92,24 +100,31 @@ describe('Map<string, Variable<Data>> - Variables as Values', () => {
     const realMap = new Map<string, number>();
 
     const addItem = command<State, { key: string; value: number }, number>(
-      (_state) => Gen.object({
-        key: Gen.constant('same-key'),  // Always use same key
-        value: Gen.constant(100)
-      }),
+      (_state) =>
+        Gen.object({
+          key: Gen.constant('same-key'), // Always use same key
+          value: Gen.constant(100),
+        }),
       async (input) => {
         realMap.set(input.key, input.value);
-        console.log(`[Executor] Set "${input.key}" = ${input.value}, map size: ${realMap.size}`);
+        console.log(
+          `[Executor] Set "${input.key}" = ${input.value}, map size: ${realMap.size}`
+        );
         return input.value;
       },
       require(() => true),
       update((state, input, valueVar) => {
         const newItems = new Map(state.items);
-        newItems.set(input.key, valueVar);  // String key, Variable value
-        console.log(`[Update] Set "${input.key}" = ${valueVar.toString()}, map size: ${newItems.size}`);
+        newItems.set(input.key, valueVar); // String key, Variable value
+        console.log(
+          `[Update] Set "${input.key}" = ${valueVar.toString()}, map size: ${newItems.size}`
+        );
         return { items: newItems };
       }),
       ensure((_before, after, _input, _output) => {
-        console.log(`[Ensure] Model size: ${after.items.size}, Real size: ${realMap.size}`);
+        console.log(
+          `[Ensure] Model size: ${after.items.size}, Real size: ${realMap.size}`
+        );
         return after.items.size === realMap.size;
       })
     );
@@ -121,14 +136,14 @@ describe('Map<string, Variable<Data>> - Variables as Values', () => {
         {
           command: addItem,
           input: { key: 'same-key', value: 100 },
-          output: { type: 'symbolic' as const, id: 0, typeName: 'number' }
+          output: { type: 'symbolic' as const, id: 0, typeName: 'number' },
         },
         {
           command: addItem,
           input: { key: 'same-key', value: 200 },
-          output: { type: 'symbolic' as const, id: 1, typeName: 'number' }
-        }
-      ]
+          output: { type: 'symbolic' as const, id: 1, typeName: 'number' },
+        },
+      ],
     };
 
     console.log('\n=== Map<string, Variable<number>> Test ===\n');
@@ -136,7 +151,9 @@ describe('Map<string, Variable<Data>> - Variables as Values', () => {
 
     console.log(`\nFinal Result: ${result.success ? 'PASS' : 'FAIL'}`);
     console.log('\nExpected: Both should have 1 entry (same key overwrites)');
-    console.log(`Actual: Model=${sequence.initialState.items.size}, Real=${realMap.size}`);
+    console.log(
+      `Actual: Model=${sequence.initialState.items.size}, Real=${realMap.size}`
+    );
 
     expect(result.success).toBeDefined();
   });

--- a/packages/hedgehog/src/worker/worker-script.ts
+++ b/packages/hedgehog/src/worker/worker-script.ts
@@ -8,13 +8,21 @@
 
 import { parentPort, workerData } from 'worker_threads';
 import { performance } from 'perf_hooks';
-import { deserializeFunction, type SerializedFunction } from './function-serializer.js';
+import {
+  deserializeFunction,
+  type SerializedFunction,
+} from './function-serializer.js';
 
 /**
  * Worker message types for communication with main thread.
  */
 type WorkerMessage =
-  | { type: 'execute-test'; testId: string; input: unknown; serializedFunction: SerializedFunction }
+  | {
+      type: 'execute-test';
+      testId: string;
+      input: unknown;
+      serializedFunction: SerializedFunction;
+    }
   | { type: 'ping' }
   | { type: 'terminate' }
   | { type: 'health-check' };
@@ -93,9 +101,10 @@ async function executeTest(
 
   try {
     // Deserialize the test function
-    const testFunction = deserializeFunction<(input: unknown) => TestResult | Promise<TestResult>>(
-      serializedFunction
-    );
+    const testFunction =
+      deserializeFunction<(input: unknown) => TestResult | Promise<TestResult>>(
+        serializedFunction
+      );
 
     // Execute the test function with timeout protection
     const result = await executeWithTimeout(testFunction, input, 30000); // 30 second timeout
@@ -114,7 +123,6 @@ async function executeTest(
       result: validatedResult,
       timing,
     });
-
   } catch (error) {
     const timing = performance.now() - startTime;
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -145,11 +153,11 @@ async function executeWithTimeout<T>(
     }, timeoutMs);
 
     Promise.resolve(fn(input))
-      .then(result => {
+      .then((result) => {
         clearTimeout(timeoutId);
         resolve(result);
       })
-      .catch(error => {
+      .catch((error) => {
         clearTimeout(timeoutId);
         reject(error);
       });
@@ -173,7 +181,10 @@ function validateTestResult(result: unknown): TestResult {
     const obj = result as Record<string, unknown>;
 
     // Validate required fields
-    if (!obj.type || !['pass', 'fail', 'discard'].includes(obj.type as string)) {
+    if (
+      !obj.type ||
+      !['pass', 'fail', 'discard'].includes(obj.type as string)
+    ) {
       throw new Error('Test result must have a valid type field');
     }
 


### PR DESCRIPTION
Adds Property.check() that throws on failure with clear formatting:
- Prominently displays shrunk counterexample
- Shows original failure when shrinking occurred
- Includes seed and size for reproduction
- Reports test statistics and classification labels

Adds forAllNamed() for variable name tracking in failures:
- forAll 0 = 42 -- x (with name)
- 42 (without name)

Variable names are preserved through classify/collect operations and shown in both counterexample and original failure output.

Also removes noisy duplicate key warning from state machine testing that fired on legitimate test cases where duplicates are intentional.