### PR TITLE
Add withExample and withExamples for manual regression testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Formatted classification statistics in failure output
 - `forAllNamed()` function for variable name tracking in failure reports
 - Variable names shown in counterexample output (e.g., `forAll 0 = 42 -- x`)
+- `Property.withExample()` method to add single regression test case
+- `Property.withExamples()` method to add multiple regression test cases at once
+- Examples tested before random generation, useful for known edge cases and manual regression testing
 
 ### Removed
 - Noisy duplicate key warning from state machine testing


### PR DESCRIPTION
Adds Property.withExample() and Property.withExamples() methods to support manual regression testing. These methods allow testing specific known edge cases before random generation starts. Multiple examples can be chained together, or bulk cases can be imported from external files. Examples are counted in test statistics and work with classify and collect operations.

This provides the foundation for regression testing without requiring auto-capture infrastructure or complex serialization.